### PR TITLE
Include sys/time.h for gettimeofday

### DIFF
--- a/cpubars.c
+++ b/cpubars.c
@@ -1,5 +1,6 @@
 // -*- c-file-style: "bsd" -*-
 
+#include <sys/time.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
Without this patch, compiling yields

```
$ cc cpubars.c -lncurses
cpubars.c: In function ‘time_usec’:
cpubars.c:141:9: warning: implicit declaration of function ‘gettimeofday’ [-Wimplicit-function-declaration]
         gettimeofday(&tv, 0);
         ^
```
