### PR TITLE
fix return type of cpustats_subtract1

### DIFF
--- a/cpubars.c
+++ b/cpubars.c
@@ -275,7 +275,7 @@ cpustats_read(struct cpustats *out)
                 epanic("failed to seek /proc/stat");
 }
 
-static bool
+static void
 cpustats_subtract1(struct cpustat *out,
                    const struct cpustat *a, const struct cpustat *b)
 {


### PR DESCRIPTION
Clang warns that this function has return type of "bool" but does not return anything:

cc    -c -o cpubars.o cpubars.c
cpubars.c:293:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
1 warning generated.