### PR TITLE
do not overflow when computing delta (iowait can decrease - see proc(5))

### DIFF
--- a/cpubars.c
+++ b/cpubars.c
@@ -329,7 +329,7 @@ cpustats_subtract1(struct cpustat *out,
 {
         out->online = a->online && b->online;
         if (out->online) {
-#define SUB(field) out->field = a->field - b->field
+#define SUB(field) out->field = a->field >= b->field ? a->field - b->field : 0
                 SUB(user);
                 SUB(nice);
                 SUB(sys);


### PR DESCRIPTION
cpubars gets SIGSEGV due to overflow when computing iowait delta

(gdb) p delta->cpus[0]
$39 = {online = true, user = 0, nice = 0, sys = 0, iowait = 18446744073709551615, irq = 0, softirq = 1}

(gdb) p after->cpus[0]
$51 = {online = true, user = 369655, nice = 612, sys = 384302, iowait = 48160, irq = 0, softirq = 798428}

(gdb) p before->cpus[0]
$52 = {online = true, user = 369655, nice = 612, sys = 384302, iowait = 48161, irq = 0, softirq = 798427}